### PR TITLE
Add Kaltura media view modes

### DIFF
--- a/config/install/core.entity_view_display.media.kaltura.default.yml
+++ b/config/install/core.entity_view_display.media.kaltura.default.yml
@@ -1,0 +1,30 @@
+uuid: 53bd3636-e130-4b7f-8821-9238ec242631
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.kaltura.field_media_oembed_video
+    - media.type.kaltura
+  module:
+    - media
+id: media.kaltura.default
+targetEntityType: media
+bundle: kaltura
+mode: default
+content:
+  field_media_oembed_video:
+    type: oembed
+    label: visually_hidden
+    settings:
+      max_width: 640
+      max_height: 480
+      loading:
+        attribute: eager
+    third_party_settings: { }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.kaltura.frameless.yml
+++ b/config/install/core.entity_view_display.media.kaltura.frameless.yml
@@ -1,0 +1,36 @@
+uuid: 06418930-4a22-4a63-a751-63c9f063a04d
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.frameless
+    - field.field.media.kaltura.field_media_oembed_video
+    - media.type.kaltura
+  module:
+    - layout_builder
+    - media
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.kaltura.frameless
+targetEntityType: media
+bundle: kaltura
+mode: frameless
+content:
+  field_media_oembed_video:
+    type: oembed
+    label: visually_hidden
+    settings:
+      max_width: 640
+      max_height: 480
+      loading:
+        attribute: eager
+    third_party_settings: { }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.kaltura.media_card.yml
+++ b/config/install/core.entity_view_display.media.kaltura.media_card.yml
@@ -1,0 +1,36 @@
+uuid: c6f97446-ac11-417c-b4cc-3a7080a13b7f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_card
+    - field.field.media.kaltura.field_media_oembed_video
+    - media.type.kaltura
+  module:
+    - layout_builder
+    - media
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.kaltura.media_card
+targetEntityType: media
+bundle: kaltura
+mode: media_card
+content:
+  field_media_oembed_video:
+    type: oembed
+    label: visually_hidden
+    settings:
+      max_width: 640
+      max_height: 480
+      loading:
+        attribute: eager
+    third_party_settings: { }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.kaltura.media_library.yml
+++ b/config/install/core.entity_view_display.media.kaltura.media_library.yml
@@ -1,0 +1,32 @@
+uuid: f0ece9ae-4fc4-4348-b26c-f5c1848e566c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.kaltura.field_media_oembed_video
+    - image.style.medium
+    - media.type.kaltura
+  module:
+    - image
+id: media.kaltura.media_library
+targetEntityType: media
+bundle: kaltura
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: { }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_media_oembed_video: true
+  name: true
+  uid: true

--- a/config/install/core.entity_view_display.media.kaltura.video_720.yml
+++ b/config/install/core.entity_view_display.media.kaltura.video_720.yml
@@ -1,0 +1,36 @@
+uuid: c222b2c2-04bd-4ee1-aee8-c8a7a4c149b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.video_720
+    - field.field.media.kaltura.field_media_oembed_video
+    - media.type.kaltura
+  module:
+    - layout_builder
+    - media
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.kaltura.video_720
+targetEntityType: media
+bundle: kaltura
+mode: video_720
+content:
+  field_media_oembed_video:
+    type: oembed
+    label: visually_hidden
+    settings:
+      max_width: 1280
+      max_height: 720
+      loading:
+        attribute: eager
+    third_party_settings: { }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/osu_media.install
+++ b/osu_media.install
@@ -213,6 +213,32 @@ function osu_media_update_10003(&$sandbox) {
 }
 
 /**
+ * Add view modes for Kaltura Video.
+ */
+function osu_media_update_10004(&$sandbox) {
+  $config_path = osu_media_get_install_location();
+  $config_source = new FileStorage($config_path);
+
+  /** @var \Drupal\Core\Config\CachedStorage $config_storage */
+  $config_storage = Drupal::service('config.storage');
+
+  $view_modes = [
+    'media.kaltura.default',
+    'media.kaltura.frameless',
+    'media.kaltura.media_card',
+    'media.kaltura.media_library',
+    'media.kaltura.video_720',
+  ];
+
+  foreach ($view_modes as $view_mode) {
+    if ($config_source->exists('core.entity_view_display.' . $view_mode)) {
+      $config_storage->write('core.entity_view_display.' . $view_mode, $config_source->read('core.entity_view_display.' . $view_mode));
+    }
+  }
+  return t('Added view modes for Kaltura Video');
+}
+
+/**
  * Get the configuration path for this module.
  *
  * @return false|string


### PR DESCRIPTION
Introduced new view modes for Kaltura media including default, frameless, media card, media library, and video_720. Updated osu_media.install to manage these configurations during module installation or updates.