### PR TITLE
Add Kaltura media type and OSU MediaSpace oEmbed support

### DIFF
--- a/config/install/core.entity_form_display.media.kaltura.default.yml
+++ b/config/install/core.entity_form_display.media.kaltura.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.kaltura.field_media_oembed_video
+    - media.type.kaltura
+  module:
+    - media
+    - path
+id: media.kaltura.default
+targetEntityType: media
+bundle: kaltura
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_oembed_video:
+    type: oembed_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  name: true

--- a/config/install/core.entity_form_display.media.kaltura.media_library.yml
+++ b/config/install/core.entity_form_display.media.kaltura.media_library.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.kaltura.field_media_oembed_video
+    - media.type.kaltura
+id: media.kaltura.media_library
+targetEntityType: media
+bundle: kaltura
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_media_oembed_video: true
+  path: true
+  status: true
+  uid: true

--- a/config/install/field.field.media.kaltura.field_media_oembed_video.yml
+++ b/config/install/field.field.media.kaltura.field_media_oembed_video.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_oembed_video
+    - media.type.kaltura
+id: media.kaltura.field_media_oembed_video
+field_name: field_media_oembed_video
+entity_type: media
+bundle: kaltura
+label: 'Kaltura URL'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/media.type.kaltura.yml
+++ b/config/install/media.type.kaltura.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - oembed_providers.bucket.kaltura
+  module:
+    - oembed_providers
+id: kaltura
+label: Kaltura
+description: ''
+source: 'oembed:kaltura'
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_oembed_video
+  thumbnails_directory: 'public://oembed_thumbnails/[date:custom:Y-m]'
+  providers: {  }
+field_map: {  }

--- a/config/install/oembed_providers.bucket.kaltura.yml
+++ b/config/install/oembed_providers.bucket.kaltura.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - oembed_providers.provider.osu_mediaspace
+id: kaltura
+label: Kaltura
+description: ''
+providers:
+  - 'OSU MediaSpace'

--- a/config/install/oembed_providers.provider.osu_mediaspace.yml
+++ b/config/install/oembed_providers.provider.osu_mediaspace.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: { }
+id: osu_mediaspace
+label: 'OSU MediaSpace'
+provider_url: 'https://media.oregonstate.edu'
+endpoints:
+  - schemes:
+      - 'https://media.oregonstate.edu/id/*'
+      - 'https://media.oregonstate.edu/media/t/*'
+    url: 'https://media.oregonstate.edu/oembed'
+    discovery: true
+    formats:
+      json: false
+      xml: false


### PR DESCRIPTION
This commit introduces a new Kaltura media type configuration along with a provider configuration for OSU MediaSpace. It includes definitions for entity forms, field storage, and media interfaces to enable oEmbed video integration from OSU MediaSpace.